### PR TITLE
feat: `equals()` should be nullable

### DIFF
--- a/src/main/kotlin/dev/ocpd/jsensible/internal/java/ParameterIsNullable.kt
+++ b/src/main/kotlin/dev/ocpd/jsensible/internal/java/ParameterIsNullable.kt
@@ -1,0 +1,28 @@
+package dev.ocpd.jsensible.internal.java
+
+import com.tngtech.archunit.core.domain.JavaMethod
+import com.tngtech.archunit.lang.ArchCondition
+import com.tngtech.archunit.lang.ConditionEvents
+import com.tngtech.archunit.lang.SimpleConditionEvent.violated
+
+object ParameterIsNullable {
+
+    /**
+     * All parameters within the method should be annotated with @Nullable
+     */
+    fun parameterIsNullable(): ArchCondition<JavaMethod> =
+        object : ArchCondition<JavaMethod>("parameters of equals method should be annotated with @Nullable") {
+            override fun check(javaMethod: JavaMethod, events: ConditionEvents) {
+                javaMethod.parameters
+                    .filter { !it.isAnnotatedWith("org.jetbrains.annotations.Nullable") }
+                    .forEach {
+                        events.add(
+                            violated(
+                                javaMethod, it.description
+                                        + " is not annotated with [org.jetbrains.annotations.Nullable]"
+                            )
+                        )
+                    }
+            }
+        }
+    }

--- a/src/main/kotlin/dev/ocpd/jsensible/rules/java/JavaRules.kt
+++ b/src/main/kotlin/dev/ocpd/jsensible/rules/java/JavaRules.kt
@@ -1,8 +1,10 @@
 package dev.ocpd.jsensible.rules.java
 
 import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
 import com.tngtech.archunit.library.GeneralCodingRules
+import dev.ocpd.jsensible.internal.java.ParameterIsNullable.parameterIsNullable
 import dev.ocpd.jsensible.internal.java.LegacyIoFile.useLegacyIoFile
 
 /**
@@ -16,7 +18,8 @@ object JavaRules {
         noLegacyIoFile(),
         noGenericExceptions(),
         noMisplacedTests(),
-        noFieldInjection()
+        noFieldInjection(),
+        equalsMethodShouldBeNullable()
     ) + Java8Rules.all() + Java11Rules.all() + Java17Rules.all()
 
     /**
@@ -88,4 +91,15 @@ object JavaRules {
     fun noFieldInjection(): ArchRule =
         GeneralCodingRules.NO_CLASSES_SHOULD_USE_FIELD_INJECTION
             .because("field injection is considered harmful and should be avoided, use constructor injection instead")
+
+    /**
+     * The operand of the equals method should be nullable
+     *
+     * Solution: Annotate @Nullable for all parameters in the equals method
+     */
+    fun equalsMethodShouldBeNullable(): ArchRule =
+        ArchRuleDefinition.methods()
+            .that().haveName("equals")
+            .should(parameterIsNullable())
+            .because("parameters in equals method should be annotated with @Nullable")
 }


### PR DESCRIPTION
`equals()` should be nullable

- Get all `equals()`
- Determine if the parameter is annotated with `@Nullable`