### PR TITLE
fix: modify `noPathsGet()` rule

### DIFF
--- a/src/main/kotlin/dev/ocpd/jsensible/rules/java/Java11Rules.kt
+++ b/src/main/kotlin/dev/ocpd/jsensible/rules/java/Java11Rules.kt
@@ -2,6 +2,7 @@ package dev.ocpd.jsensible.rules.java
 
 import com.tngtech.archunit.lang.ArchRule
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.*
@@ -38,7 +39,9 @@ object Java11Rules {
      * Solution: Replace [Paths.get] with [Path.of].
      */
     fun noPathsGet(): ArchRule =
-        noClasses().should().callMethod(Paths::class.java, "get")
+        noClasses()
+            .should().callMethod(Paths::class.java, "get", String::class.java, Array<String>::class.java)
+            .orShould().callMethod(Paths::class.java, "get", URI::class.java)
             .`as`("call [Paths.get]")
             .because("JDK recommends to obtain a [Path] via the [Path.of] methods instead")
 }

--- a/src/test/java/dev/ocpd/jsensible/rules/java/NoPathsGet.java
+++ b/src/test/java/dev/ocpd/jsensible/rules/java/NoPathsGet.java
@@ -1,0 +1,45 @@
+package dev.ocpd.jsensible.rules.java;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@SuppressWarnings("unused")
+public class NoPathsGet {
+
+    public static class Compliant {
+
+        public Path compliant1() {
+            return Path.of("/test");
+        }
+
+        public Path compliant2() {
+            return Path.of("/test1", "test2");
+        }
+
+        public Path compliant3() {
+            return Path.of(URI.create("test"));
+        }
+    }
+
+    public static class NonCompliant1 {
+
+        public Path nonCompliant() {
+            return Paths.get("/test");
+        }
+    }
+
+    public static class NonCompliant2 {
+
+        public Path nonCompliant() {
+            return Paths.get("/test1", "/test2");
+        }
+    }
+
+    public static class NonCompliant3 {
+
+        public Path nonCompliant() {
+            return Paths.get(URI.create("/test"));
+        }
+    }
+}

--- a/src/test/kotlin/dev/ocpd/jsensible/rules/java/Java11RulesTest.kt
+++ b/src/test/kotlin/dev/ocpd/jsensible/rules/java/Java11RulesTest.kt
@@ -7,4 +7,7 @@ class Java11RulesTest {
 
     @Test
     fun noOptionalGet() = testRule<NoOptionalGet>(Java11Rules.noOptionalGet())
+
+    @Test
+    fun noPathsGet() = testRule<NoPathsGet>(Java11Rules.noPathsGet())
 }


### PR DESCRIPTION
When using ArchUnit's `callMethod()`,we should include the actual number of parameters of the method.