### PR TITLE
fix: remove `ArchRule.as()` on negative condition

### DIFF
--- a/src/main/kotlin/dev/ocpd/jsensible/rules/java/Java11Rules.kt
+++ b/src/main/kotlin/dev/ocpd/jsensible/rules/java/Java11Rules.kt
@@ -25,7 +25,6 @@ object Java11Rules {
      */
     fun noOptionalGet(): ArchRule =
         noClasses().should().callMethod(Optional::class.java, "get")
-            .`as`("call [Optional.get]")
             .because("JDK recommends [Optional.orElseThrow] as the preferred alternative")
 
     /**
@@ -39,6 +38,5 @@ object Java11Rules {
      */
     fun noPathsGet(): ArchRule =
         noClasses().should().callMethod(Paths::class.java, "get")
-            .`as`("call [Paths.get]")
             .because("JDK recommends to obtain a [Path] via the [Path.of] methods instead")
 }

--- a/src/main/kotlin/dev/ocpd/jsensible/rules/jpa/JpaRules.kt
+++ b/src/main/kotlin/dev/ocpd/jsensible/rules/jpa/JpaRules.kt
@@ -27,6 +27,5 @@ object JpaRules {
      */
     fun noEagerFetch(): ArchRule =
         noMembers().should(useEagerFetch())
-            .`as`("use eager fetch")
             .because("no property should be fetched eagerly by default")
 }


### PR DESCRIPTION
Remove `ArchRule.as()` on negative condition to avoid rule description errors.