### PR TITLE
fix: `noPathsGet()` rule

### DIFF
--- a/src/main/kotlin/dev/ocpd/jsensible/rules/java/Java11Rules.kt
+++ b/src/main/kotlin/dev/ocpd/jsensible/rules/java/Java11Rules.kt
@@ -2,6 +2,7 @@ package dev.ocpd.jsensible.rules.java
 
 import com.tngtech.archunit.lang.ArchRule
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.*
@@ -37,6 +38,8 @@ object Java11Rules {
      * Solution: Replace [Paths.get] with [Path.of].
      */
     fun noPathsGet(): ArchRule =
-        noClasses().should().callMethod(Paths::class.java, "get")
+        noClasses()
+            .should().callMethod(Paths::class.java, "get", String::class.java, Array<String>::class.java)
+            .orShould().callMethod(Paths::class.java, "get", URI::class.java)
             .because("JDK recommends to obtain a [Path] via the [Path.of] methods instead")
 }


### PR DESCRIPTION
The test cases for this rule will be added later.